### PR TITLE
Be forward compatible with rust-lang/rust#59928

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -185,7 +185,7 @@ impl fmt::Display for Code {
 impl TryFrom<u8> for Code {
     type Error = error::Error;
 
-    fn try_from(i: u8) -> Result<Self, Self::Error> {
+    fn try_from(i: u8) -> Result<Self, error::Error> {
         match i {
             0 => Ok(Code::Req),
             1 => Ok(Code::Ok),


### PR DESCRIPTION
Hello! In https://github.com/rust-lang/rust/pull/59928 we are making https://github.com/rust-lang/rust/issues/57644 a deny-by-default lint. To be forward compatible with that, here's a simple fix. Thank you for you understanding!